### PR TITLE
Capture InterruptMain during takeMVar

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+NEXT VERSION []
+------------------
+* Crash of python's main thread when one attempts to interrupt it fixed.
+
 0.1.1 [2025.02.13]
 ------------------
 * Number of deadlocks in `runPyInMain` fixed:


### PR DESCRIPTION
Otherwise if exception wasn't captured during execution it will surface when we lock on MVar