### PR TITLE
Add workaround for python3.11

### DIFF
--- a/src/Python/Internal/Eval.hs
+++ b/src/Python/Internal/Eval.hs
@@ -439,6 +439,17 @@ doInitializePythonIO = do
           goto error;
       };
       PyConfig_Clear(&cfg);
+      // This is hack for python<=3.11.
+      //
+      // Somehow we may end up in stet where thread ID of main thread is not equal
+      // to main thread's one. Importing threading seems to fix it. However exact
+      // reason for such behavior is unknown
+      if( PY_MINOR_VERSION <= 11 ) {
+          PyObject *threading = PyImport_ImportModule("threading");
+          if( PyErr_Occurred() ) {
+              PyErr_Clear();
+          }
+      }
       // Release GIL so other threads may take it
       PyEval_SaveThread();
       return 0;


### PR DESCRIPTION
Without this that checks that current_thread()==main_thread() fail intermittently for python3.11 In that case thread used by runInMain has correct thread id (as returned by PyThread_get_thread_ident) but isn't considered main by python interpreter.

Importing threading module fixes this. Why? It's unclear

Fixes #45